### PR TITLE
Allow opening new Nemo tab from navbar

### DIFF
--- a/src/components/navigationBar/NavigationBar.tsx
+++ b/src/components/navigationBar/NavigationBar.tsx
@@ -30,7 +30,7 @@ export function NavigationBar() {
       style={{ borderBottom: "1px solid #dddddd" }}
     >
       <Container fluid>
-        <Navbar.Brand>
+        <Navbar.Brand href="./" target="_blank">
           <img
             src={logoNemo}
             alt="Nemo - Graph Rule Engine"
@@ -39,7 +39,7 @@ export function NavigationBar() {
         </Navbar.Brand>
         <Navbar.Toggle aria-controls="navigation-bar-nav" />
         <Navbar.Collapse id="navigation-bar-nav">
-          <Nav className="me-auto">
+          <Nav className="me-auto" activeKey="NONE_WE_DO_NOT_WANT_ACTIVE_HIGHLIGHTING">
             <ShowExamplesButton />
             <NavDropdown
               title={
@@ -60,6 +60,9 @@ export function NavigationBar() {
                 {t("common:giveFeedback")}
               </NavDropdown.Item>
             </NavDropdown>
+            <Nav.Link href="./" target="_blank">
+              <Icon name="file-earmark-plus" /> {t("newNemoTab")}
+            </Nav.Link>
           </Nav>
           <Navbar.Text>
             <span style={{ fontSize: ".8em" }}>Version: {nemoVersion}</span>{" "}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -8,7 +8,8 @@
   },
   "navigationBar": {
     "documentation": "Documentation",
-    "sourceCodeNemo": "Nemo on Github"
+    "sourceCodeNemo": "Nemo on GitHub",
+    "newNemoTab": "New Nemo Tab"
   },
   "examples": {
     "introduction": "The following examples illustrate how Nemo can be used:",

--- a/src/i18n/qqq.json
+++ b/src/i18n/qqq.json
@@ -11,7 +11,8 @@
 	},
 	"navigationBar": {
 		"documentation": "This is the title of a menu item in the “Help” menu, linking to the documentation for Nemo and the rule language.",
-		"sourceCodeNemo": "This is the title of a menu item in the “Help” menu, linking to the GitHub repository for the Nemo rule engine."
+		"sourceCodeNemo": "This is the title of a menu item in the “Help” menu, linking to the GitHub repository for the Nemo rule engine.",
+		"newNemoTab": "This is the title for the navbar item that opens a new Nemo tab."
 	},
 	"examples": {
 		"introduction": "This is the introductory paragraph shown before the list of example programs in the example selection modal.",


### PR DESCRIPTION
Both the "brand" logo and a newly introduced navbar item now allow to open a new Nemo tab.  
Closes #29 
Closes #30 